### PR TITLE
Disable double-tap zoom in iOS Safari

### DIFF
--- a/css/party.css
+++ b/css/party.css
@@ -315,7 +315,8 @@ main {
     color: #FFFBDC;
     font-size: 50px;
     text-shadow: 1px 1px 2px black, 0 0 1px black;
-    cursor: pointer; }
+    cursor: pointer;
+    touch-action: manipulation; }
     main button:active {
       -webkit-transform: scale(0.96);
       -ms-transform: scale(0.96);

--- a/sass/partials/_main.scss
+++ b/sass/partials/_main.scss
@@ -47,6 +47,7 @@ main { @include flex-container(center); width:100%; height: 80vh;
     box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.8), inset 0px 2px 5px rgba(0, 0, 0, 0.35), 2px 2px 2px rgba(0,0,0,0.3);
     display: inline-block;
     color:#FFFBDC; font-size:50px; text-shadow:1px 1px 2px black, 0 0 1px black; cursor: pointer;
+    touch-action: manipulation;
     &:active { transform: scale(0.96); }
   }
 


### PR DESCRIPTION
iOS 10 [removed support](https://webkit.org/blog/7367/new-interaction-behaviors-in-ios-10/) for meta viewport `user-scalable=no`, which made it really hard to fully party in iOS Safari. Setting the [`touch-action`](https://devdocs.io/css/touch-action) property stops the crazy zooming when you tap the button fast and lets us get back to maximum party.